### PR TITLE
Encryption disabled on doGetVault returns nil (godoc and test)

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.8
+    tag: 1.16.2
 
 inputs:
   - name: dp-upload-service

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.15.8
+    tag: 1.16.2
 
 inputs:
   - name: dp-upload-service

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dp-upload-service
 
-go 1.15
+go 1.16
 
 require (
 	github.com/ONSdigital/dp-healthcheck v1.0.5

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -86,7 +86,9 @@ func (e *Init) DoGetS3Uploaded(ctx context.Context, cfg *config.Config) (upload.
 	return s3Client, nil
 }
 
-// DoGetVault returns a VaultClient
+// DoGetVault returns a VaultClient unless encryption is disabled
+//
+// If cfg.EncryptionDisabled is true then the function returns nil
 func (e *Init) DoGetVault(ctx context.Context, cfg *config.Config) (upload.VaultClienter, error) {
 	if cfg.EncryptionDisabled {
 		return nil, nil

--- a/service/initialise_test.go
+++ b/service/initialise_test.go
@@ -236,3 +236,18 @@ func TestGetHealthCheck(t *testing.T) {
 		})
 	})
 }
+
+func TestInit_DoGetVault(t *testing.T) {
+	Convey("Given a an empty initialiser struct", t, func() {
+		init := Init{}
+		Convey("When DoGetVault is called with encryption disabled", func() {
+			cfg, err := config.Get()
+			So(err, ShouldBeNil)
+			vault, err := init.DoGetVault(ctx, cfg)
+			So(err, ShouldBeNil)
+			Convey("Then the returned vault client should be nil", func() {
+				So(vault, ShouldBeNil)
+			})
+		})
+	})
+}

--- a/service/initialise_test.go
+++ b/service/initialise_test.go
@@ -240,13 +240,25 @@ func TestGetHealthCheck(t *testing.T) {
 func TestInit_DoGetVault(t *testing.T) {
 	Convey("Given a an empty initialiser struct", t, func() {
 		init := Init{}
+		cfg, err := config.Get()
+
 		Convey("When DoGetVault is called with encryption disabled", func() {
-			cfg, err := config.Get()
+			cfg.EncryptionDisabled = true
 			So(err, ShouldBeNil)
 			vault, err := init.DoGetVault(ctx, cfg)
 			So(err, ShouldBeNil)
 			Convey("Then the returned vault client should be nil", func() {
 				So(vault, ShouldBeNil)
+			})
+		})
+
+		Convey("When DoGetVault is called with encryption enabled", func() {
+			cfg.EncryptionDisabled = false
+			So(err, ShouldBeNil)
+			vault, err := init.DoGetVault(ctx, cfg)
+			So(err, ShouldBeNil)
+			Convey("Then the returned vault client should not be nil", func() {
+				So(vault, ShouldNotBeNil)
 			})
 		})
 	})


### PR DESCRIPTION
### What

Updates as suggested in release PR #17 
- Clarify godoc on `service.DoGetVault`
- Add a unit test for nil vault when cfg.EncryptionDisabled
- Update go to 1.16.2

### How to review

Check code covers points raised in PR.
Ensure tests pass

### Who can review

Anyone but me