### PR TITLE
Split out resumable filename path

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -15,6 +15,7 @@ import (
 )
 
 type Metadata struct {
+	Path    string `schema:"path" validate:"required,aws-upload-key"`
 	IsPublishable bool   `schema:"isPublishable" validate:"required"`
 	CollectionId  string `schema:"collectionId" validate:"required"`
 	Title         string `schema:"title"`
@@ -35,7 +36,7 @@ func mimeValidator(fl validator.FieldLevel) bool {
 
 func awsUploadKeyValidator(fl validator.FieldLevel) bool {
 	path := fl.Field().String()
-	matched, _ := regexp.MatchString("^[a-zA-Z]{1}", path)
+	matched, _ := regexp.MatchString("^[a-z\\.\\-0-9]{3,63}$", path)
 
 	return matched
 }

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -94,7 +94,8 @@ func TestRequiredFields(t *testing.T) {
 func TestPathValid(t *testing.T) {
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "/invalid/upload-key/file.csv")
+	formWriter.WriteField("resumableFilename", "file.csv")
+	formWriter.WriteField("path", "UploadKey")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -120,7 +121,8 @@ func TestPathValid(t *testing.T) {
 func TestTypeValid(t *testing.T) {
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -146,7 +148,8 @@ func TestTypeValid(t *testing.T) {
 func TestFileWasSupplied(t *testing.T) {
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -180,7 +183,8 @@ func TestSuccessfulStorageOfCompleteFileReturns200(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -212,7 +216,8 @@ func TestChunkTooSmallReturns400(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -242,7 +247,8 @@ func TestFilePathExistsInFilesAPIReturns409(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -274,7 +280,8 @@ func TestInvalidContentReturns500(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")
@@ -307,7 +314,8 @@ func TestUnexpectedErrorReturns500(t *testing.T) {
 
 	b := &bytes.Buffer{}
 	formWriter := multipart.NewWriter(b)
-	formWriter.WriteField("resumableFilename", "valid/path.csv")
+	formWriter.WriteField("resumableFilename", "path.csv")
+	formWriter.WriteField("path", "valid")
 	formWriter.WriteField("isPublishable", "true")
 	formWriter.WriteField("collectionId", "1234567890")
 	formWriter.WriteField("title", "A New File")

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var stubStoreFunction = func(ctx context.Context, uf files.Metadata, r files.Resumable, c []byte) (bool, error) {
+var stubStoreFunction = func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, c []byte) (bool, error) {
 	return false, nil
 }
 
@@ -172,7 +172,7 @@ func TestFileWasSupplied(t *testing.T) {
 func TestSuccessfulStorageOfCompleteFileReturns200(t *testing.T) {
 	payload := "TEST DATA"
 	funcCalled := false
-	st := func(ctx context.Context, uf files.Metadata, r files.Resumable, fileContent []byte) (bool, error) {
+	st := func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, fileContent []byte) (bool, error) {
 		funcCalled = true
 		assert.Equal(t, payload, string(fileContent))
 		return true, nil
@@ -206,7 +206,7 @@ func TestSuccessfulStorageOfCompleteFileReturns200(t *testing.T) {
 
 func TestChunkTooSmallReturns400(t *testing.T) {
 	payload := "TEST DATA"
-	st := func(ctx context.Context, uf files.Metadata, r files.Resumable, fileContent []byte) (bool, error) {
+	st := func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, fileContent []byte) (bool, error) {
 		return true, files.ErrChunkTooSmall
 	}
 
@@ -236,7 +236,7 @@ func TestChunkTooSmallReturns400(t *testing.T) {
 }
 
 func TestFilePathExistsInFilesAPIReturns409(t *testing.T) {
-	st := func(ctx context.Context, uf files.Metadata, r files.Resumable, fileContent []byte) (bool, error) {
+	st := func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, fileContent []byte) (bool, error) {
 		return false, files.ErrFilesAPIDuplicateFile
 	}
 
@@ -268,7 +268,7 @@ func TestFilePathExistsInFilesAPIReturns409(t *testing.T) {
 }
 
 func TestInvalidContentReturns500(t *testing.T) {
-	st := func(ctx context.Context, uf files.Metadata, r files.Resumable, fileContent []byte) (bool, error) {
+	st := func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, fileContent []byte) (bool, error) {
 		return false, files.ErrFileAPICreateInvalidData
 	}
 
@@ -301,7 +301,7 @@ func TestInvalidContentReturns500(t *testing.T) {
 }
 
 func TestUnexpectedErrorReturns500(t *testing.T) {
-	st := func(ctx context.Context, uf files.Metadata, r files.Resumable, fileContent []byte) (bool, error) {
+	st := func(ctx context.Context, uf files.StoreMetadata, r files.Resumable, fileContent []byte) (bool, error) {
 		return false, errors.New("its broken")
 	}
 

--- a/features/uploading_a_file.feature
+++ b/features/uploading_a_file.feature
@@ -19,10 +19,11 @@ Feature: Uploading a file
         russ,3
         """
     When I upload the file "test-data/populations.csv" with the following form resumable parameters:
-      | resumableFilename    | data/populations.csv |
+      | resumableFilename    | populations.csv      |
       | resumableType        | text/csv             |
       | resumableTotalChunks | 1                    |
       | resumableChunkNumber | 1                    |
+      | path                 | data                 |
     Then the HTTP status code should be "200"
     And the path "/data/populations.csv" should be available in the S3 bucket matching content using encryption key "abcdef123456789z":
         """
@@ -54,10 +55,11 @@ Feature: Uploading a file
 
   Scenario: File upload is marked as started when first chunk is uploaded
     When I upload the file "features/countries.csv" with the following form resumable parameters:
-      | resumableFilename    | data/countries.csv |
+      | resumableFilename    | countries.csv      |
       | resumableType        | text/csv           |
       | resumableTotalChunks | 2                  |
       | resumableChunkNumber | 1                  |
+      | path                 | data               |
     Then the HTTP status code should be "100"
     And the file upload should be marked as started using payload:
         """
@@ -76,10 +78,11 @@ Feature: Uploading a file
 
   Scenario: File upload is marked as started when first chunk is uploaded
     When I upload the file "features/countries.csv" with the following form resumable parameters:
-      | resumableFilename    | data/countries.csv |
+      | resumableFilename    | countries.csv      |
       | resumableType        | text/csv           |
       | resumableTotalChunks | 2                  |
       | resumableChunkNumber | 1                  |
+      | path                 | data               |
     Then the HTTP status code should be "100"
     And the file upload should be marked as started using payload:
         """
@@ -99,15 +102,17 @@ Feature: Uploading a file
 
   Scenario: File ends up in bucket as result of uploading second chunk
     Given the 1st part of the file "features/countries.csv" has been uploaded with resumable parameters:
-      | resumableFilename    | data/countries.csv |
+      | resumableFilename    | countries.csv      |
       | resumableType        | text/csv           |
       | resumableTotalChunks | 2                  |
       | resumableChunkNumber | 1                  |
+      | path                 | data               |
     When I upload the file "features/countries.csv" with the following form resumable parameters:
-      | resumableFilename    | data/countries.csv |
+      | resumableFilename    | countries.csv      |
       | resumableType        | text/csv           |
       | resumableTotalChunks | 2                  |
       | resumableChunkNumber | 2                  |
+      | path                 | data               |
     Then the HTTP status code should be "200"
     And the file should be marked as uploaded using payload:
         """

--- a/files/store.go
+++ b/files/store.go
@@ -84,11 +84,8 @@ func firstChunk(currentChunk int64) bool { return currentChunk == 1 }
 
 func (s Store) UploadFile(ctx context.Context, metadata StoreMetadata, resumable Resumable, content []byte) (bool, error) {
 
-	fullPath := fmt.Sprintf("%s/%s",resumable.Path, resumable.FileName)
-	metadata.Path = fullPath
-
 	var encryptionkey []byte
-	vaultPath := fmt.Sprintf("%s/%s", s.vaultPath, fullPath)
+	vaultPath := fmt.Sprintf("%s/%s", s.vaultPath, metadata.Path)
 	if firstChunk(resumable.CurrentChunk) {
 		encryptionkey = s.keyGenerator()
 		if err := s.registerFileUpload(metadata); err != nil {
@@ -110,7 +107,7 @@ func (s Store) UploadFile(ctx context.Context, metadata StoreMetadata, resumable
 	}
 
 	upr := s3client.UploadPartRequest{
-		UploadKey:   fullPath,
+		UploadKey:   metadata.Path,
 		Type:        resumable.Type,
 		ChunkNumber: resumable.CurrentChunk,
 		TotalChunks: resumable.TotalChunks,
@@ -127,7 +124,7 @@ func (s Store) UploadFile(ctx context.Context, metadata StoreMetadata, resumable
 	}
 
 	uc := uploadComplete{
-		Path: fullPath,
+		Path: metadata.Path,
 		ETag: strings.Trim(response.Etag, "\""),
 	}
 

--- a/files/store_test.go
+++ b/files/store_test.go
@@ -66,7 +66,7 @@ func (s *StoreSuite) TestFileUploadIsRegisteredWithFilesApi() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 	s.NoError(err)
 }
 
@@ -78,7 +78,7 @@ func (s *StoreSuite) TestFileAlreadyRegisteredWithFilesApi() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 	s.Equal(files.ErrFilesAPIDuplicateFile, err)
 }
 
@@ -90,7 +90,7 @@ func (s *StoreSuite) TestFileRegisteredWithInvalidContent() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 	s.Equal(files.ErrFileAPICreateInvalidData, err)
 }
 
@@ -102,7 +102,7 @@ func (s *StoreSuite) TestFileRegisterReturnsUnknownError() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 	s.Equal(files.ErrUnknownError, err)
 }
 
@@ -114,7 +114,7 @@ func (s *StoreSuite) TestFileRegisterReturnsMalformedJSON() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 
 	s.Error(err)
 }
@@ -122,7 +122,7 @@ func (s *StoreSuite) TestFileRegisterReturnsMalformedJSON() {
 func (s *StoreSuite) TestErrorConnectingToRegisterFiles() {
 	store := files.NewStore("does.not.work", s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 	s.Equal(files.ErrConnectingToFilesApi, err)
 }
 
@@ -134,7 +134,7 @@ func (s *StoreSuite) TestErrorStoringEncryptionKeyInVault() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, firstResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, firstResumable, []byte("CONTENT"))
 
 	s.Equal(files.ErrVaultWrite, err)
 }
@@ -146,7 +146,7 @@ func (s *StoreSuite) TestErrorReadingEncryptionKeyFromValue() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 
 	s.Equal(files.ErrVaultRead, err)
 }
@@ -158,7 +158,7 @@ func (s StoreSuite) TestUploadPartReturnsAnError() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrS3Upload, err)
 }
 
@@ -169,7 +169,7 @@ func (s StoreSuite) TestUploadChunkTooSmallReturnsErrChuckTooSmall() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrChunkTooSmall, err)
 }
 
@@ -178,7 +178,7 @@ func (s StoreSuite) TestFileNotFoundWhenMarkedAsUploaded() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrFileNotFound, err)
 }
 
@@ -187,7 +187,7 @@ func (s StoreSuite) TestReturnsConflictWhenFileInUnexpectedState() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrFileStateConflict, err)
 }
 
@@ -196,13 +196,13 @@ func (s StoreSuite) TestUploadCompleteUnknownError() {
 
 	store := files.NewStore(s.fakeFilesApi.ResolveURL(""), s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrUnknownError, err)
 }
 
 func (s *StoreSuite) TestErrorConnectingToUploadComplete() {
 	store := files.NewStore("does.not.work", s.mockS3, s.fakeKeyGenerator, s.mockVault, vaultPath)
 
-	_, err := store.UploadFile(context.Background(), files.Metadata{}, lastResumable, []byte("CONTENT"))
+	_, err := store.UploadFile(context.Background(), files.StoreMetadata{}, lastResumable, []byte("CONTENT"))
 	s.Equal(files.ErrConnectingToFilesApi, err)
 }


### PR DESCRIPTION
### What

Upload metadata now requires separate Path and ResumableFilename data,
Path = hardcoded section representing publishing "area"
ResumableFilename = just the filename with no prepended paths

### How to review

Test uploading with Path and ResumableFilename
ResumableFilename is validated according to S3 upload-key requirements 
by regex ^[a-z\.\-0-9]{3,63}$ i.e. between 3 and 63 characters long, lowercase inc dot, hyphen and digits

