### PR TITLE
Update linter version

### DIFF
--- a/ci/scripts/lint.sh
+++ b/ci/scripts/lint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eux
 
 pushd dp-upload-service
-  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.43.0
+  go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
   make lint
 popd


### PR DESCRIPTION
### What

Updated golang-ci linting version to 1.52.2 to align to other static file publishing linter standards.

### How to review

Visual review

### Who can review

Anyone
