### PR TITLE
Readd nomad vault policies

### DIFF
--- a/dp-upload-service.nomad
+++ b/dp-upload-service.nomad
@@ -67,6 +67,10 @@ job "dp-upload-service" {
         source      = "${NOMAD_TASK_DIR}/vars-template"
         destination = "${NOMAD_TASK_DIR}/vars"
       }
+
+      vault {
+        policies = ["dp-upload-service"]
+      }
     }
   }
 }


### PR DESCRIPTION
### What

Readded removed vault policies, these were taken out as part of the double encryption removal, but should not have been as it allows the dp-config secrets into the service

### How to review

Visual check

### Who can review

Anyone
