### PR TITLE
added bundleId into metadata struct

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -25,6 +25,7 @@ type Metadata struct {
 	Path          string  `schema:"path" validate:"required,aws-upload-key"`
 	IsPublishable *bool   `schema:"isPublishable,omitempty" validate:"required"`
 	CollectionId  *string `schema:"collectionId,omitempty"`
+	BundleId      *string `schema:"bundleId,omitempty"`
 	Title         string  `schema:"title"`
 	SizeInBytes   int     `schema:"resumableTotalSize" validate:"required"`
 	Type          string  `schema:"resumableType" validate:"required"`
@@ -128,6 +129,7 @@ func getStoreMetadata(metadata Metadata, resumable files.Resumable) filesAPI.Fil
 		Path:          fmt.Sprintf("%s/%s", metadata.Path, resumable.FileName),
 		IsPublishable: *metadata.IsPublishable,
 		CollectionID:  metadata.CollectionId,
+		BundleID:      metadata.BundleId,
 		Title:         metadata.Title,
 		SizeInBytes:   uint64(metadata.SizeInBytes),
 		Type:          metadata.Type,

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -118,6 +118,19 @@ func (s UploadTestSuite) TestFileWasSupplied() {
 	s.Contains(string(response), "FileForm")
 }
 
+func (s UploadTestSuite) TestFileWasSuppliedWithBundleId() {
+	b, formWriter := generateFormWriterWithBundleId("valid")
+	formWriter.Close()
+
+	h := api.CreateV1UploadHandler(stubStoreFunction)
+
+	h.ServeHTTP(rec, generateRequest(b, formWriter))
+
+	s.Equal(http.StatusBadRequest, rec.Code)
+	response, _ := io.ReadAll(rec.Body)
+	s.Contains(string(response), "FileForm")
+}
+
 func (s UploadTestSuite) TestSuccessfulStorageOfCompleteFileReturns201() {
 	payload := "TEST DATA"
 	funcCalled := false
@@ -240,6 +253,21 @@ func generateFormWriter(path string) (*bytes.Buffer, *multipart.Writer) {
 	formWriter.WriteField("path", path)
 	formWriter.WriteField("isPublishable", "false")
 	formWriter.WriteField("collectionId", "1234567890")
+	formWriter.WriteField("title", "A New File")
+	formWriter.WriteField("resumableTotalSize", "1478")
+	formWriter.WriteField("resumableType", "text/csv")
+	formWriter.WriteField("licence", "OGL v3")
+	formWriter.WriteField("licenceUrl", "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+	return b, formWriter
+}
+
+func generateFormWriterWithBundleId(path string) (*bytes.Buffer, *multipart.Writer) {
+	b := &bytes.Buffer{}
+	formWriter := multipart.NewWriter(b)
+	formWriter.WriteField("resumableFilename", "file.csv")
+	formWriter.WriteField("path", path)
+	formWriter.WriteField("isPublishable", "false")
+	formWriter.WriteField("bundleId", "1234567890")
 	formWriter.WriteField("title", "A New File")
 	formWriter.WriteField("resumableTotalSize", "1478")
 	formWriter.WriteField("resumableType", "text/csv")

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ exclude github.com/gogo/protobuf v1.2.1
 exclude github.com/prometheus/client_golang v0.9.3
 
 require (
-	github.com/ONSdigital/dp-api-clients-go/v2 v2.264.0
+	github.com/ONSdigital/dp-api-clients-go/v2 v2.265.0
 	github.com/ONSdigital/dp-component-test v0.19.0
 	github.com/ONSdigital/dp-healthcheck v1.6.3
 	github.com/ONSdigital/dp-net/v2 v2.22.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.264.0 h1:QGchY7CDhDo8muluBEsMGxudREGDdboHNOoYaYdoUSc=
-github.com/ONSdigital/dp-api-clients-go/v2 v2.264.0/go.mod h1:jsZvK/OUrHigv5tNKvA+HwgBu7F6XnRldO4IvMv52Lg=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.265.0 h1:NrBaAv0Xwe87W1E5kLHiRJpPlWRawT+2VkX0eLJFbho=
+github.com/ONSdigital/dp-api-clients-go/v2 v2.265.0/go.mod h1:jsZvK/OUrHigv5tNKvA+HwgBu7F6XnRldO4IvMv52Lg=
 github.com/ONSdigital/dp-component-test v0.19.0 h1:b3kGNd/aTiUFDKpak/sPsMZfgfZeqiHXLZD42fDh9b4=
 github.com/ONSdigital/dp-component-test v0.19.0/go.mod h1:/2UE5kxiBJtTN7+8FOSPt0sUUdbIohm3haUJsvNgtLI=
 github.com/ONSdigital/dp-healthcheck v1.6.3 h1:EekpiLjiXQtetNDmworUhZZMDvcG70b2cZYhVhEuUSs=

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -212,6 +212,11 @@ paths:
           required: true
           type: string
         - in: formData
+          name: bundleId
+          description: The ID of the bundle to which the file belongs
+          required: false
+          type: string
+        - in: formData
           name: file
           description: Specifies the file to be uploaded
           required: true


### PR DESCRIPTION
### What

- updated Metadata struct
- added unit tests
- updated `dp-clients-api-go` version
- updated swagger file

### How to review

- check if the changes are okay
- check if all the build checks are passed
- test the following endpoints

1. When POST /upload-new is invoked with a bundleId then it is registered against the file metadata in the files database.
2. When POST /upload-new is invoked without a bundleId then no bundle_id is registered in the database for the file.

### Who can review

Anyone