### PR TITLE
update error code for existing file name

### DIFF
--- a/api/upload.go
+++ b/api/upload.go
@@ -89,8 +89,8 @@ func CreateV1UploadHandler(storeFile StoreFile) http.HandlerFunc {
 		allPartsUploaded, err := storeFile(augmentedContext, getStoreMetadata(metadata, resumable), resumable, payload)
 		if err != nil {
 			switch err {
-			case files.ErrFilesAPIDuplicateFile:
-				writeError(w, buildErrors(err, "DuplicateFile"), http.StatusBadRequest)
+			case filesAPI.ErrFileAlreadyRegistered:
+				writeError(w, buildErrors(err, "DuplicateFile"), http.StatusConflict)
 			case files.ErrFileAPICreateInvalidData:
 				writeError(w, buildErrors(err, "RemoteValidationError"), http.StatusInternalServerError)
 			case files.ErrChunkTooSmall:

--- a/api/upload_test.go
+++ b/api/upload_test.go
@@ -176,7 +176,7 @@ func (s UploadTestSuite) TestChunkTooSmallReturns400() {
 
 func (s UploadTestSuite) TestFilePathExistsInFilesAPIReturns409() {
 	st := func(ctx context.Context, uf filesAPI.FileMetaData, r files.Resumable, fileContent []byte) (bool, error) {
-		return false, files.ErrFilesAPIDuplicateFile
+		return false, filesAPI.ErrFileAlreadyRegistered
 	}
 
 	b, formWriter := generateFormWriter("valid")
@@ -187,7 +187,7 @@ func (s UploadTestSuite) TestFilePathExistsInFilesAPIReturns409() {
 	h := api.CreateV1UploadHandler(st)
 	h.ServeHTTP(rec, generateRequest(b, formWriter))
 
-	s.Equal(http.StatusBadRequest, rec.Code)
+	s.Equal(http.StatusConflict, rec.Code)
 	response, _ := io.ReadAll(rec.Body)
 	s.Contains(string(response), "DuplicateFile")
 }

--- a/features/uploading_a_file.feature
+++ b/features/uploading_a_file.feature
@@ -114,4 +114,21 @@ Feature: Uploading a file
       And the files api PATCH request with path ("data/authorized.csv") should contain a default authorization header
       And the HTTP status code should be "201"
 
+    Scenario: Uploading a file that already exists returns 409 Conflict
+      Given dp-files-api has a file "/data/populations.csv" already registered
+      And the data file "populations.csv" with content:
+          """
+          mark,1
+          jon,2
+          russ,3
+          """
+      When I upload the file "test-data/populations.csv" with the following form resumable parameters:
+        | resumableFilename    | populations.csv      |
+        | resumableType        | text/csv             |
+        | resumableTotalChunks | 1                    |
+        | resumableChunkNumber | 1                    |
+        | path                 | data                 |
+      Then the HTTP status code should be "409"
+      And the response should contain error code "DuplicateFile"
+
 


### PR DESCRIPTION
### What

Jira - https://jira.ons.gov.uk/browse/DIS-3469
Updated so that if a "file already exists" error is returned from `dp-files-api` for a file uploaded via the `/upload-new` endpoint, then a `409 `status code response is returned instead of `500`

### How to review

Confirm changes make sense, tests pass

### Who can review

Anyone